### PR TITLE
Prevent chkbit from reading all .chkbit files at once to avoid openin…

### DIFF
--- a/lib/chkbit.js
+++ b/lib/chkbit.js
@@ -108,7 +108,7 @@ function idxLoad(opt, dir) {
   // load the md5 index from the last run (if any)
   var file=idxName(dir);
   if (fs.existsSync(file)) {
-    return Promise.resolve(fs.readFile(file, "utf8"))
+    return Promise.resolve(fs.readFileSync(file, "utf8"))
     .then(function(text) {
       var data=JSON.parse(text);
       if (!data.ts) {} // ignore md5 package bug in v1.0.0

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "lightweight bitrot detection tool",
   "main": "./lib/chkbit.js",
   "author": "Christian Zangl",
-  "version": "1.3.1",
+  "version": "1.3.1a",
   "tags": [
     "bitrot"
   ],


### PR DESCRIPTION
…g more files than the system can handle and getting an ENFILE or EMFILE error
