### PR TITLE
Fix for problem with hard links and add support for dot files and a global ignore.

### DIFF
--- a/bin/chkbit
+++ b/bin/chkbit
@@ -33,6 +33,7 @@ var opt={
   overwrite: args.force,
   verbose: args.v,
   readonly: args.verify,
+  excludeDotFiles: args.nodot,
 };
 
 if (args.params.length<1) {
@@ -43,6 +44,7 @@ if (args.params.length<1) {
   console.log("-del    delete all .chkbit files");
   console.log("-p=N    factor for parallel operations (default 5)");
   console.log("-i      use node's md5 (ignores -p)");
+  console.log("-nodot  exclude files / directories beginning with '.'");
   console.log("-v      verbose output");
   console.log("Status codes:");
   console.log("'E'     error, md5 mismatch");

--- a/lib/chkbit.js
+++ b/lib/chkbit.js
@@ -95,6 +95,12 @@ function idxSave(opt, dir, data) {
   // save the md5 index
   return Promise.resolve(JSON.stringify(data))
   .then(function(data) {
+    if (fs.existsSync(idxName(dir))) {
+      // If the chkbit file is hard linked it could have two directories
+      // fighting over its content.  Unlink before writing to ensure it is not
+      // hard linked.
+      fs.unlinkSync(idxName(dir));
+    }
     return fs.writeFileSync(idxName(dir), JSON.stringify({
       data: data,
       md5: md5x(data).toString(),

--- a/lib/chkbit.js
+++ b/lib/chkbit.js
@@ -40,6 +40,8 @@ var limiter=function(max) {
 
 var md5Limit=limiter(5), indexLimit=limiter(15);
 
+var ignGlobal=ignLoadSync({ verbose: true }, require("os").homedir());
+
 function exec(dir, bin, args) {
   // execute a process while limiting parallel executions
   return md5Limit(function() { return new Promise(function(resolve, reject) {
@@ -153,6 +155,21 @@ function ignLoad(opt, dir) {
   } else return Promise.resolve([]);
 }
 
+// Synchronous version for loading the global ignore
+function ignLoadSync(opt, dir) {
+  // load ignore list (if any)
+  var file=ignName(dir);
+  if (fs.existsSync(file)) {
+    var text=fs.readFileSync(file, "utf8");
+      return (text||"")
+        .split("\n")
+        .map(function(line){ return line.replace("\r", ""); })
+        .filter(function(name) {
+          return name && name[0]!='#' && name.trim().length>0;
+        });
+  } else return [];
+}
+
 function idxDel(dir) {
   var file=idxName(dir);
   // fs.exists(file) appears to be buggy
@@ -170,6 +187,7 @@ function getDir(opt, dir) {
           || name==="."
           || name[0]==="~") return;
         if (ign.find(function(pat) { return pat===name; })) return; // todo: support expressions
+        if (ignGlobal.find(function(pat) { return pat===name; })) return; // todo: support expressions
         var file=path.join(dir, name);
         try {
           var stats=fs.lstatSync(file);

--- a/lib/chkbit.js
+++ b/lib/chkbit.js
@@ -186,6 +186,7 @@ function getDir(opt, dir) {
           || name===".."
           || name==="."
           || name[0]==="~") return;
+        if (opt.excludeDotFiles && name[0]===".") return;
         if (ign.find(function(pat) { return pat===name; })) return; // todo: support expressions
         if (ignGlobal.find(function(pat) { return pat===name; })) return; // todo: support expressions
         var file=path.join(dir, name);

--- a/lib/chkbit.js
+++ b/lib/chkbit.js
@@ -165,7 +165,10 @@ function getDir(opt, dir) {
     return ignLoad(opt, dir).then(function(ign) {
       var files=[], dirs=[];
       list.forEach(function(name) {
-        if (name[0]==="." || name[0]==="~") return;
+        if (name===".chkbit"
+          || name===".."
+          || name==="."
+          || name[0]==="~") return;
         if (ign.find(function(pat) { return pat===name; })) return; // todo: support expressions
         var file=path.join(dir, name);
         try {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "lightweight bitrot detection tool",
   "main": "./lib/chkbit.js",
   "author": "Christian Zangl",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "keywords": [
     "bitrot"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "lightweight bitrot detection tool",
   "main": "./lib/chkbit.js",
   "author": "Christian Zangl",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "keywords": [
     "bitrot"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "lightweight bitrot detection tool",
   "main": "./lib/chkbit.js",
   "author": "Christian Zangl",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "keywords": [
     "bitrot"
   ],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "lightweight bitrot detection tool",
   "main": "./lib/chkbit.js",
   "author": "Christian Zangl",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "keywords": [
     "bitrot"
   ],


### PR DESCRIPTION
Included are four commits.  The first, for a very challenging problem I encountered which turned out to be the result of an application converting a directory structure while maintaining a copy of the old via hard links.  The .chkbit files were then shared between two directories with differing contents to horrible result.  This was fixed by unlinking before writing.

The others are inclusion of dot files / directories (.bashrc, .git, etc) since it's nice to guard against rot in those as well; a global .chkbitignore to filter out some of the dot files; and a flag to support previous behavior with respect to dot files / directories.

Thank you!
Mark